### PR TITLE
Potential fix for code scanning alert no. 18: Stored cross-site scripting

### DIFF
--- a/src/lib/helpers/article.ts
+++ b/src/lib/helpers/article.ts
@@ -73,14 +73,27 @@ function extractYearFromPath(fullPath: string): string {
   return year ?? "unknown";
 }
 
+/**
+ * Derive a slug for an article.
+ * Only allows alphanumeric, dash, and underscore. Unsafe characters are removed.
+ */
 function deriveSlug(
   frontmatterSlug: string | undefined,
   fullPath: string,
 ): string {
+  // Helper to sanitize slug: only [a-zA-Z0-9-_], convert spaces to dashes, remove other chars
+  const sanitize = (slug: string) =>
+    slug
+      .toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/[^a-z0-9\-_]/g, "")
+      .replace(/-+/g, "-")
+      .replace(/^[-_]+|[-_]+$/g, ""); // Remove leading/trailing dashes/underscores
+
   if (frontmatterSlug && frontmatterSlug.trim().length > 0)
-    return frontmatterSlug.trim();
+    return sanitize(frontmatterSlug.trim());
   const base = path.basename(fullPath, path.extname(fullPath));
-  return base;
+  return sanitize(base);
 }
 
 export function getAllArticleFiles(): string[] {


### PR DESCRIPTION
Potential fix for [https://github.com/praveentcom/devcard/security/code-scanning/18](https://github.com/praveentcom/devcard/security/code-scanning/18)

To fix this problem, we need to ensure that any path segment or slug derived from directory or file names is always normalized and validated so that:
- Only a safe, restrictive character set is allowed in slugs/filenames used as route parameters or href segments (e.g., `[a-zA-Z0-9\-_]+`).
- Any value used in an `href` prop (or as a URL segment anywhere) must be checked or sanitized to prevent introducing characters that could terminate attributes or introduce non-HTTP(S) schemes, such as `javascript:`.
- This means, before passing any such value (specifically, the `slug` generated from file names) into places like `href` in your components, we must ensure it matches a strict pattern.

The best place to enforce this is either:
1. At the point the slug is derived (within `deriveSlug` in `src/lib/helpers/article.ts`), or
2. Before passing data from backend to frontend components, by mapping/validating results.

Because the bug is fundamentally about slugs derived from filenames, the most robust fix is to strictly sanitize/validate the returned slug in `deriveSlug` to only allow safe characters, rejecting or cleaning others.  
Additionally, if there is any chance that the year part could be tainted (if not already strictly validated), apply a similar restriction.

**Required changes:**
- In `src/lib/helpers/article.ts`, update the `deriveSlug` function to only allow a safe set of characters in the returned slug, e.g., filter out anything not matching `/[a-zA-Z0-9\-_]+/`.
- Consider also enforcing such rules on the `year` value if its source is not fully trusted.
- Document this function as rejecting unsafe slugs.
- No changes are required in component files if this is handled at the data layer.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
