### PR TITLE
Disable horizontal scrollbar always

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -67,7 +67,7 @@ export default function RootLayout({
         >
           <PrefetchProvider>
             <Header />
-            <main id="main-content" className="flex-1">
+            <main id="main-content" className="flex-1 no-horizontal-scroll">
               <AnimatedLayout>{children}</AnimatedLayout>
             </main>
             <Footer />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -115,12 +115,24 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    /* Prevent any element from causing horizontal scroll */
+    max-width: 100%;
+    box-sizing: border-box;
   }
+  
+  html {
+    @apply overflow-x-hidden;
+  }
+  
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-x-hidden;
   }
+  
   .page-container {
     @apply container mx-auto px-4 py-4 md:py-0 max-w-3xl min-w-0;
+    /* Ensure page container never exceeds viewport width */
+    max-width: min(100vw - 2rem, 48rem); /* 48rem = max-w-3xl, 2rem = px-4 * 2 */
+    box-sizing: border-box;
   }
 }
 
@@ -180,6 +192,9 @@
   /* Reusable article content styles */
   .article-base {
     @apply max-w-none min-w-0 overflow-hidden;
+    /* Ensure article content never causes horizontal scroll */
+    width: 100%;
+    max-width: 100%;
   }
 
   .article-base > p:first-child,
@@ -355,6 +370,9 @@
   /* Mobile-specific overrides for content */
   .article-base pre {
     @apply overflow-x-auto max-w-full;
+    /* Ensure pre blocks don't cause horizontal page scroll */
+    width: 100%;
+    box-sizing: border-box;
   }
 
   /* Ensure code blocks don't break */
@@ -369,10 +387,27 @@
 
   .article-base table {
     @apply w-full overflow-x-auto block whitespace-nowrap md:whitespace-normal md:table;
+    /* Ensure tables don't cause horizontal page scroll */
+    max-width: 100%;
+    box-sizing: border-box;
   }
 
   /* Badges */
   .badge-container {
     @apply text-xs cursor-pointer flex items-center gap-1.5 hover:bg-accent hover:text-accent-foreground transition-colors;
+  }
+
+  /* Utility class to prevent horizontal scroll */
+  .no-horizontal-scroll {
+    overflow-x: hidden;
+    max-width: 100%;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  /* Ensure all main containers respect viewport width */
+  main, section, article, div[class*="container"] {
+    max-width: 100%;
+    box-sizing: border-box;
   }
 }


### PR DESCRIPTION
Prevent horizontal page scrolling by applying global and component-specific CSS rules.

---
[Slack Thread](https://praveent.slack.com/archives/C0966CKGH7D/p1756308964579789?thread_ts=1756308964.579789&cid=C0966CKGH7D)

<a href="https://cursor.com/background-agent?bcId=bc-46a28ccc-3e6c-4920-8b8d-62763b3bd96a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-46a28ccc-3e6c-4920-8b8d-62763b3bd96a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

