### PR TITLE
Adjust profile page layout for mobile

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -100,7 +100,7 @@ export default async function ProjectPage({ params }: PageProps) {
 
           {/* Mobile layout: buttons below description in grid */}
           {(project.url || project.githubUrl) && (
-            <div className={`md:hidden grid gap-1.5 grid-cols-2`}>
+            <div className={`md:hidden grid gap-1.5 grid-cols-1`}>
               {project.url && (
                 <Button variant="default" size="sm" asChild>
                   <a
@@ -130,7 +130,7 @@ export default async function ProjectPage({ params }: PageProps) {
             </div>
           )}
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {project.date && (
               <SectionCard title="Project date">
                 <div className="flex items-center gap-1.5">


### PR DESCRIPTION
Adjust mobile grid layouts on the project detail page to improve readability and button display.

The original layout caused the website button to be cut off and the contributors/date section to be cramped on mobile devices. This change ensures these elements are properly displayed in a single column on mobile, while maintaining the desktop layout.

---
[Slack Thread](https://praveent.slack.com/archives/C0966CKGH7D/p1756309434800249?thread_ts=1756309434.800249&cid=C0966CKGH7D)

<a href="https://cursor.com/background-agent?bcId=bc-ebb1d688-d646-48c8-83f7-19612bf6c28e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ebb1d688-d646-48c8-83f7-19612bf6c28e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

