### PR TITLE
Preserve line numbers during horizontal scroll

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -364,9 +364,9 @@
     font-family:
       ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono",
       Menlo, monospace;
-    /* Allow horizontal scrolling for content */
-    overflow-x: auto;
+    /* Prevent line wrapping but don't scroll individual lines */
     white-space: nowrap;
+    flex-shrink: 0;
   }
 
   /* Dark mode line number adjustments */
@@ -387,6 +387,8 @@
     /* Ensure the flex container allows horizontal scrolling */
     display: flex;
     min-width: max-content;
+    /* Prevent individual line containers from shrinking */
+    flex-shrink: 0;
   }
 
   /* Ensure code blocks don't break */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -348,7 +348,7 @@
 
   /* Line numbers styling */
   .article-base .line-number {
-    @apply select-none text-xs text-muted-foreground inline-block text-right pr-3 bg-muted/40 border-r border-border flex-shrink-0;
+    @apply select-none text-xs text-muted-foreground inline-block text-right pr-3 bg-muted/80 border-r border-border flex-shrink-0;
     font-family:
       ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono",
       Menlo, monospace;
@@ -357,9 +357,9 @@
     position: sticky;
     left: 0;
     z-index: 1;
-    /* Add backdrop blur for better visibility */
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    /* Subtle backdrop blur for better visibility without being jarring */
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
   }
 
   .article-base .line-content {
@@ -374,10 +374,10 @@
 
   /* Dark mode line number adjustments */
   .dark .article-base .line-number {
-    @apply text-muted-foreground/70 bg-muted/30 border-border/50;
-    /* Maintain backdrop blur in dark mode */
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    @apply text-muted-foreground/70 bg-muted/60 border-border/50;
+    /* Subtle backdrop blur in dark mode */
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
   }
 
   /* Mobile-specific overrides for content */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -353,6 +353,10 @@
       ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono",
       Menlo, monospace;
     min-width: 2rem;
+    /* Make line numbers sticky during horizontal scroll */
+    position: sticky;
+    left: 0;
+    z-index: 1;
   }
 
   .article-base .line-content {
@@ -360,6 +364,9 @@
     font-family:
       ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono",
       Menlo, monospace;
+    /* Allow horizontal scrolling for content */
+    overflow-x: auto;
+    white-space: nowrap;
   }
 
   /* Dark mode line number adjustments */
@@ -373,6 +380,13 @@
     /* Ensure pre blocks don't cause horizontal page scroll */
     width: 100%;
     box-sizing: border-box;
+  }
+
+  /* Code container with line numbers support */
+  .article-base pre > div {
+    /* Ensure the flex container allows horizontal scrolling */
+    display: flex;
+    min-width: max-content;
   }
 
   /* Ensure code blocks don't break */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -357,6 +357,9 @@
     position: sticky;
     left: 0;
     z-index: 1;
+    /* Add backdrop blur for better visibility */
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
   }
 
   .article-base .line-content {
@@ -372,6 +375,9 @@
   /* Dark mode line number adjustments */
   .dark .article-base .line-number {
     @apply text-muted-foreground/70 bg-muted/30 border-border/50;
+    /* Maintain backdrop blur in dark mode */
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
   }
 
   /* Mobile-specific overrides for content */


### PR DESCRIPTION
Preserve line numbers during horizontal code scrolling to improve readability.

Previously, when code blocks contained long lines that required horizontal scrolling, the line numbers would scroll out of view along with the code content. This change ensures line numbers remain fixed on the left.

---
[Slack Thread](https://praveent.slack.com/archives/C0966CKGH7D/p1756310158784199?thread_ts=1756310158.784199&cid=C0966CKGH7D)

<a href="https://cursor.com/background-agent?bcId=bc-1485f0ec-e81f-4cf0-aaaa-1c414a801aed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1485f0ec-e81f-4cf0-aaaa-1c414a801aed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

