### PR TITLE
Align header menu right on desktop

### DIFF
--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -91,7 +91,7 @@ export function Header() {
         )}
       >
         <div className="page-container py-0">
-          <div className="hidden md:flex items-center justify-start py-4 gap-6 h-16">
+          <div className="hidden md:flex items-center justify-end py-4 gap-6 h-16">
             <h1 className="text-md font-medium">
               <Link
                 href={nameHref}


### PR DESCRIPTION
Right-align the desktop header menu by changing `justify-start` to `justify-end`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9440b4b-aa4d-4597-866e-1b4313c0fde1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9440b4b-aa4d-4597-866e-1b4313c0fde1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

