### PR TITLE
Fix header name and menu alignment

### DIFF
--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -91,7 +91,7 @@ export function Header() {
         )}
       >
         <div className="page-container py-0">
-          <div className="hidden md:flex items-center justify-end py-4 gap-6 h-16">
+          <div className="hidden md:flex items-center justify-between py-4 h-16">
             <h1 className="text-md font-medium">
               <Link
                 href={nameHref}


### PR DESCRIPTION
Adjust header alignment on desktop to place the name on the left and the menu on the right.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b705180-7915-4b1b-b8c4-22e3b74e1676">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b705180-7915-4b1b-b8c4-22e3b74e1676">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

